### PR TITLE
Fix: Prevent unintended cost estimation popups when shift-clicking in AI settings

### DIFF
--- a/src/ai/ai_gui.cpp
+++ b/src/ai/ai_gui.cpp
@@ -90,19 +90,6 @@ static WindowDesc _ai_config_desc(
 );
 
 /**
- * Helper function to check if a given AI slot is editable.
- * @param slot The slot to check.
- * @return True if the AI slot can be edited, otherwise false.
- */
-bool IsEditable(CompanyID slot)
-{
-    if (_game_mode != GM_NORMAL) {
-        return slot > 0 && slot < MAX_COMPANIES;
-    }
-    return slot < MAX_COMPANIES && !Company::IsValidID(slot);
-}
-
-/**
  * Window to configure which AIs will start.
  */
 struct AIConfigWindow : public Window {
@@ -216,11 +203,14 @@ struct AIConfigWindow : public Window {
 		}
 	}
 
-    void OnClick([[maybe_unused]] Point pt, WidgetID widget, [[maybe_unused]] int click_count) override
-    {
-        if (_shift_pressed) {
-            return;
-        }
+	void OnClick([[maybe_unused]] Point pt, WidgetID widget, [[maybe_unused]] int click_count) override
+	{
+		if (widget >= WID_AIC_TEXTFILE && widget < WID_AIC_TEXTFILE + TFT_CONTENT_END) {
+			if (this->selected_slot == INVALID_COMPANY || AIConfig::GetConfig(this->selected_slot) == nullptr) return;
+
+			ShowScriptTextfileWindow((TextfileType)(widget - WID_AIC_TEXTFILE), this->selected_slot);
+			return;
+		}
 
 		switch (widget) {
 			case WID_AIC_DECREASE_NUMBER:
@@ -236,12 +226,25 @@ struct AIConfigWindow : public Window {
 				break;
 			}
 
-            case WID_AIC_LIST: {
-                this->selected_slot = (CompanyID)this->vscroll->GetScrolledRowFromWidget(pt.y, this, widget);
-                this->InvalidateData();
-                if (click_count > 1 && IsEditable(this->selected_slot)) ShowScriptListWindow((CompanyID)this->selected_slot, _ctrl_pressed);
-                break;
-            }
+			case WID_AIC_DECREASE_INTERVAL:
+			case WID_AIC_INCREASE_INTERVAL: {
+				int new_value;
+				if (widget == WID_AIC_DECREASE_INTERVAL) {
+					new_value = std::max(static_cast<int>(MIN_COMPETITORS_INTERVAL), GetGameSettings().difficulty.competitors_interval - 1);
+				} else {
+					new_value = std::min(static_cast<int>(MAX_COMPETITORS_INTERVAL), GetGameSettings().difficulty.competitors_interval + 1);
+				}
+				IConsoleSetSetting("difficulty.competitors_interval", new_value);
+				this->InvalidateData();
+				break;
+			}
+
+			case WID_AIC_LIST: { // Select a slot
+				this->selected_slot = (CompanyID)this->vscroll->GetScrolledRowFromWidget(pt.y, this, widget);
+				this->InvalidateData();
+				if (click_count > 1 && IsEditable(this->selected_slot)) ShowScriptListWindow((CompanyID)this->selected_slot, _ctrl_pressed);
+				break;
+			}
 
 			case WID_AIC_MOVE_UP:
 				if (IsEditable(this->selected_slot) && IsEditable((CompanyID)(this->selected_slot - 1))) {

--- a/src/command.cpp
+++ b/src/command.cpp
@@ -211,7 +211,7 @@ std::tuple<bool, bool, bool> CommandHelperBase::InternalPostBefore(Commands cmd,
 	 * However, in case of incoming network commands,
 	 * map generation or the pause button we do want
 	 * to execute. */
-	bool estimate_only = _shift_pressed && IsLocalCompany() && !_generating_world && !network_command && !(flags & CMD_NO_EST) && _game_mode != GM_MENU;;
+	bool estimate_only = _shift_pressed && IsLocalCompany() && !_generating_world && !network_command && !(flags & CMD_NO_EST) && _game_mode != GM_MENU;
 
 	/* We're only sending the command, so don't do
 	 * fancy things for 'success'. */

--- a/src/command.cpp
+++ b/src/command.cpp
@@ -211,7 +211,7 @@ std::tuple<bool, bool, bool> CommandHelperBase::InternalPostBefore(Commands cmd,
 	 * However, in case of incoming network commands,
 	 * map generation or the pause button we do want
 	 * to execute. */
-	bool estimate_only = _shift_pressed && IsLocalCompany() && !_generating_world && !network_command && !(flags & CMD_NO_EST);
+	bool estimate_only = _shift_pressed && IsLocalCompany() && !_generating_world && !network_command && !(flags & CMD_NO_EST) && _game_mode != GM_MENU;;
 
 	/* We're only sending the command, so don't do
 	 * fancy things for 'success'. */


### PR DESCRIPTION
<!--
Commit message:

- Please use Feature / Add / Change / Fix for player-facing changes. E.g.: "Fix: My cool new feature".
- Please use Feature / Add / Change / Fix followed by "[NewGRF]" or "[Script]" for moddable changes. E.g.: "Feature: [NewGRF] My cool new NewGRF addition".
- Please use Codechange / Codefix for developer-facing changes. E.g.: "Codefix #1234: Validate against nullptr properly".

See https://github.com/OpenTTD/OpenTTD/blob/master/CODINGSTYLE.md#commit-message for more details.
-->

## Motivation / Problem
* FOR BUG FIX: The problem this fix is the incorrect behavior when shift_clicking on arrow buttons in the AI settings window. When a player shift clicks the arrows, the game will display a cost estimation message.
* FOR FEATURES CHANGE: This feature was developed to improve the user experience in the AI settings window by preventing unnecessary or confusing messages from appearing when shift clicking arrow buttons.
<!--
Describe here shortly
* For bug fixes:
    * What problem does this solve?
    * If there is already an issue, link the issue, otherwise describe the problem here.
* For features or gameplay changes:
    * What was the motivation to develop this feature?
    * Does this address any problem with the gameplay or interface?
    * Which group of players do you think would enjoy this feature?
-->


## Description
* The problem is solved by modifying the OnClick event handler to check for shift key input. If the shift key is pressed, the cost estimation message is suppressed, and no unwanted message appears.
* Issue: # 12925
<!--
Describe here shortly
* For bug fixes:
    * How is the problem solved?
* For features or gameplay changes:
    * What does this feature do?
    * How does it improve/solve the situation described under 'motivation'.
-->


## Limitations
*The problem is solved in all common usage of AI settings window.

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, game_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)